### PR TITLE
remove .isRequired from style proptype

### DIFF
--- a/src/Pie.js
+++ b/src/Pie.js
@@ -50,7 +50,11 @@ Pie.propTypes = {
   doughnut: React.PropTypes.bool.isRequired,
   series: React.PropTypes.array.isRequired,
   sliceColor: React.PropTypes.array.isRequired,
-  style: View.propTypes.style.isRequired,
+  style: View.propTypes.style,
+};
+
+Pie.defaultProps = {
+  style: {},
 };
 
 export default Pie;


### PR DESCRIPTION
it turns out that we can't require style proptypes, this throws an error. I'm extremely sorry that all these PR's are being sent. I've done some extensive testing with the module and I think this is the last of the warnings.